### PR TITLE
Fix ItemsPatcher - media patching

### DIFF
--- a/src/main/java/eu/sshopencloud/marketplace/services/items/ItemsPatcher.java
+++ b/src/main/java/eu/sshopencloud/marketplace/services/items/ItemsPatcher.java
@@ -65,10 +65,17 @@ class ItemsPatcher {
 
         if (Objects.isNull(itemCore.getMedia()) || itemCore.getMedia().isEmpty()) {
             itemCore.setMedia(currentItemDto.getMedia().stream()
-                    .map(cim -> new ItemMediaCore(new MediaDetailsId(cim.getInfo().getMediaId()), cim.getCaption(),
-                            new ConceptId(cim.getConcept().getCode(),
-                                    new VocabularyId(cim.getConcept().getVocabulary().getCode()),
-                                    cim.getConcept().getUri())))
+                    .map(cim -> {
+                        // Media may exist without an associated concept
+                        ConceptId conceptId = null;
+                        if (Objects.nonNull(cim.getConcept())) {
+                            conceptId = new ConceptId(cim.getConcept().getCode(),
+                                    new VocabularyId(cim.getConcept().getVocabulary().getCode()), cim.getConcept().getUri());
+                        }
+                        // Create media core with concept (may be null)
+                        return new ItemMediaCore(
+                                new MediaDetailsId(cim.getInfo().getMediaId()), cim.getCaption(), conceptId);
+                    })
                     .collect(Collectors.toList()));
         }
 


### PR DESCRIPTION
Problem
ItemsPatcher.patchItemCore() method throws NPE when patchin items that have media object with null concepts.
Error is as follows:
`Cannot invoke "eu.sshopencloud.marketplace.dto.vocabularies.ConceptBasicDto.getCode()" 
because the return value of "eu.sshopencloud.marketplace.dto.items.ItemMediaDto.getConcept()" is null`

When preserving existing media during patch operations, logic attempts to copy media from exsiting object, however media items
may legitimately have null concepts, which causes the NPE 

Solution
Added null check before accessing the concept object,
Change should not affect existing media