### PR TITLE
Minor OpenAPI Documentation Improvements

### DIFF
--- a/src/main/java/eu/sshopencloud/marketplace/controllers/actors/ActorController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/actors/ActorController.java
@@ -28,7 +28,7 @@ public class ActorController {
 
     @Operation(summary = "Get list of actors in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PaginatedActors> getActors(@RequestParam(value = "page", required = false) Integer page,
+    public ResponseEntity<PaginatedActors> getActors(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                      @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(actorService.getActors(pageCoordsValidator.validate(page, perpage)));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/actors/ActorController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/actors/ActorController.java
@@ -29,7 +29,7 @@ public class ActorController {
     @Operation(summary = "Get list of actors in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedActors> getActors(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                     @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                     @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(actorService.getActors(pageCoordsValidator.validate(page, perpage)));
     }

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/auth/UserController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/auth/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
     public ResponseEntity<PaginatedUsers> getUsers(@RequestParam(value = "order", required = false) UserOrder order,
                                                    @RequestParam(value = "q", required = false) String q,
                                                    @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                   @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                   @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(userService.getUsers(order, q, pageCoordsValidator.validate(page, perpage)));
     }

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/auth/UserController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/auth/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedUsers> getUsers(@RequestParam(value = "order", required = false) UserOrder order,
                                                    @RequestParam(value = "q", required = false) String q,
-                                                   @RequestParam(value = "page", required = false) Integer page,
+                                                   @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                    @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(userService.getUsers(order, q, pageCoordsValidator.validate(page, perpage)));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/collections/CollectionController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/collections/CollectionController.java
@@ -23,7 +23,7 @@ public class CollectionController {
     @Operation(summary = "Get all collections in pages")
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedCollections> getCollections(
-            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
             @RequestParam(value = "perpage", required = false) Integer perpage,
             @RequestParam(value = "private", defaultValue = "false") boolean privateOnly) throws PageTooLargeException {
 

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/collections/CollectionController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/collections/CollectionController.java
@@ -24,7 +24,7 @@ public class CollectionController {
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedCollections> getCollections(
             @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-            @RequestParam(value = "perpage", required = false) Integer perpage,
+            @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage,
             @RequestParam(value = "private", defaultValue = "false") boolean privateOnly) throws PageTooLargeException {
 
         return ResponseEntity.ok(

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/datasets/DatasetController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/datasets/DatasetController.java
@@ -35,7 +35,7 @@ public class DatasetController {
     @Operation(summary = "Retrieve all datasets in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedDatasets> getDatasets(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                         @RequestParam(value = "perpage", required = false) Integer perpage,
+                                                         @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage,
                                                          @RequestParam(value = "approved", defaultValue = "true") boolean approved)
             throws PageTooLargeException {
         return ResponseEntity.ok(datasetService.getDatasets(pageCoordsValidator.validate(page, perpage), approved));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/datasets/DatasetController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/datasets/DatasetController.java
@@ -34,7 +34,7 @@ public class DatasetController {
 
     @Operation(summary = "Retrieve all datasets in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PaginatedDatasets> getDatasets(@RequestParam(value = "page", required = false) Integer page,
+    public ResponseEntity<PaginatedDatasets> getDatasets(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                          @RequestParam(value = "perpage", required = false) Integer perpage,
                                                          @RequestParam(value = "approved", defaultValue = "true") boolean approved)
             throws PageTooLargeException {

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/inbox/InboxController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/inbox/InboxController.java
@@ -5,6 +5,7 @@ import eu.sshopencloud.marketplace.dto.inbox.PaginatedMessages;
 import eu.sshopencloud.marketplace.services.inbox.MessagesService;
 import eu.sshopencloud.marketplace.validators.PageCoordsValidator;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class InboxController {
     @Operation(summary = "Get user massages")
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedMessages> getUserMessages(
-            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
             @RequestParam(value = "perpage", required = false) Integer perpage) throws PageTooLargeException {
 
         return ResponseEntity.ok(

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/inbox/InboxController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/inbox/InboxController.java
@@ -26,7 +26,7 @@ public class InboxController {
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedMessages> getUserMessages(
             @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-            @RequestParam(value = "perpage", required = false) Integer perpage) throws PageTooLargeException {
+            @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage) throws PageTooLargeException {
 
         return ResponseEntity.ok(
                 messagesService.getUserMessages(

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/items/ItemController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/items/ItemController.java
@@ -8,6 +8,7 @@ import eu.sshopencloud.marketplace.dto.items.PaginatedItemsBasic;
 import eu.sshopencloud.marketplace.services.items.*;
 import eu.sshopencloud.marketplace.validators.PageCoordsValidator;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class ItemController {
     @Operation(summary = "Get all draft-items available in pages")
     @GetMapping(path = "/draft-items", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemsBasic<ItemBasicDto>> getMyDraftItems(@RequestParam(value = "order", required = false) ItemOrder order,
-                                                               @RequestParam(value = "page", required = false) Integer page,
+                                                               @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getMyDraftItems(order, pageCoordsValidator.validate(page, perpage)));
@@ -35,7 +36,7 @@ public class ItemController {
     @Operation(summary = "Get all deleted-items available in pages")
     @GetMapping(path = "/deleted-items", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemsBasic<ItemBasicDto>> getDeletedItems(@RequestParam(value = "order", required = false) ItemOrder order,
-                                                               @RequestParam(value = "page", required = false) Integer page,
+                                                               @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getDeletedItems(order, pageCoordsValidator.validate(page, perpage)));
@@ -44,7 +45,7 @@ public class ItemController {
     @Operation(summary = "Get all contributed-items available in pages")
     @GetMapping(path = "/contributed-items", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemsBasic<ItemExtBasicDto>> getContributedItems(@RequestParam(value = "order", required = false) ItemOrder order,
-                                                               @RequestParam(value = "page", required = false) Integer page,
+                                                               @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getContributedItems(order, pageCoordsValidator.validate(page, perpage)));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/items/ItemController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/items/ItemController.java
@@ -27,7 +27,7 @@ public class ItemController {
     @GetMapping(path = "/draft-items", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemsBasic<ItemBasicDto>> getMyDraftItems(@RequestParam(value = "order", required = false) ItemOrder order,
                                                                @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                               @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                               @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getMyDraftItems(order, pageCoordsValidator.validate(page, perpage)));
     }
@@ -37,7 +37,7 @@ public class ItemController {
     @GetMapping(path = "/deleted-items", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemsBasic<ItemBasicDto>> getDeletedItems(@RequestParam(value = "order", required = false) ItemOrder order,
                                                                @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                               @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                               @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getDeletedItems(order, pageCoordsValidator.validate(page, perpage)));
     }
@@ -46,7 +46,7 @@ public class ItemController {
     @GetMapping(path = "/contributed-items", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemsBasic<ItemExtBasicDto>> getContributedItems(@RequestParam(value = "order", required = false) ItemOrder order,
                                                                @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                               @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                               @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getContributedItems(order, pageCoordsValidator.validate(page, perpage)));
     }

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/items/ItemRelationController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/items/ItemRelationController.java
@@ -27,7 +27,7 @@ public class ItemRelationController {
 
     @Operation(summary = "Retrieve all types of relations between items")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PaginatedItemRelation> getItemRelations(@RequestParam(value = "page", required = false) Integer page,
+    public ResponseEntity<PaginatedItemRelation> getItemRelations(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                   @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
 

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/items/ItemRelationController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/items/ItemRelationController.java
@@ -28,7 +28,7 @@ public class ItemRelationController {
     @Operation(summary = "Retrieve all types of relations between items")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemRelation> getItemRelations(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                                  @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                                  @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
 
         return ResponseEntity.ok(itemRelationService.getItemRelations(pageCoordsValidator.validate(page, perpage)));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/publications/PublicationController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/publications/PublicationController.java
@@ -35,7 +35,7 @@ public class PublicationController {
     @Operation(summary = "Retrieve all publications in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedPublications> getPublications(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                                 @RequestParam(value = "perpage", required = false) Integer perpage,
+                                                                 @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage,
                                                                  @RequestParam(value = "approved", defaultValue = "true") boolean approved)
             throws PageTooLargeException {
 

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/publications/PublicationController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/publications/PublicationController.java
@@ -34,7 +34,7 @@ public class PublicationController {
 
     @Operation(summary = "Retrieve all publications in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PaginatedPublications> getPublications(@RequestParam(value = "page", required = false) Integer page,
+    public ResponseEntity<PaginatedPublications> getPublications(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                  @RequestParam(value = "perpage", required = false) Integer perpage,
                                                                  @RequestParam(value = "approved", defaultValue = "true") boolean approved)
             throws PageTooLargeException {

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/search/SearchController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/search/SearchController.java
@@ -43,7 +43,7 @@ class SearchController {
             @RequestParam(value = "categories", required = false) List<ItemCategory> categories,
             @RequestParam(value = "order", required = false) List<ItemSearchOrder> order,
             @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-            @RequestParam(value = "perpage", required = false) Integer perpage,
+            @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage,
             @RequestParam(value = "advanced", defaultValue = "false") boolean advanced,
             @RequestParam(value = "includeSteps", defaultValue = "false") boolean includeSteps,
             @Parameter(
@@ -69,7 +69,7 @@ class SearchController {
     public ResponseEntity<PaginatedSearchConcepts> searchConcepts(@RequestParam(value = "q", required = false) String q,
                                                                   @RequestParam(value = "types", required = false) List<String> types,
                                                                   @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                                  @RequestParam(value = "perpage", required = false) Integer perpage,
+                                                                  @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage,
                                                                   @Parameter(
                                                                           description = "Facets parameters should be provided with putting multiple f.{filter-name}={value} as request parameters. Allowed filter names: "
                                                                                   + SearchFilter.CONCEPT_INDEX_TYPE_FILTERS + ".", schema = @Schema(type = "string"))
@@ -95,7 +95,7 @@ class SearchController {
     @Operation(description = "Search among actors.")
     public ResponseEntity<PaginatedSearchActor> searchActors(@RequestParam(value = "q", required = false) String q,
                                                              @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                             @RequestParam(value = "perpage", required = false) Integer perpage,
+                                                             @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage,
                                                              @Parameter(
                                                                      description = "Dynamic property filter parameters should be provided with putting multiple d.{property}={expression} as request parameters. Allowed property codes: "
                                                                              + " name, email, website, external-identifier .", schema = @Schema(type = "string"))
@@ -115,7 +115,7 @@ class SearchController {
             @RequestParam(value = "q", required = false) String q,
             @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
             @RequestParam(value = "advanced", defaultValue = "false") boolean advanced,
-            @RequestParam(value = "perpage", required = false) Integer perpage)
+            @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
 
         return ResponseEntity.ok(searchService.searchCollections(q, advanced, pageCoordsValidator.validate(page, perpage)));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/search/SearchController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/search/SearchController.java
@@ -42,7 +42,7 @@ class SearchController {
             @RequestParam(required = false) MultiValueMap<String, String> d,
             @RequestParam(value = "categories", required = false) List<ItemCategory> categories,
             @RequestParam(value = "order", required = false) List<ItemSearchOrder> order,
-            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
             @RequestParam(value = "perpage", required = false) Integer perpage,
             @RequestParam(value = "advanced", defaultValue = "false") boolean advanced,
             @RequestParam(value = "includeSteps", defaultValue = "false") boolean includeSteps,
@@ -68,7 +68,7 @@ class SearchController {
     @Operation(description = "Search among concepts.")
     public ResponseEntity<PaginatedSearchConcepts> searchConcepts(@RequestParam(value = "q", required = false) String q,
                                                                   @RequestParam(value = "types", required = false) List<String> types,
-                                                                  @RequestParam(value = "page", required = false) Integer page,
+                                                                  @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                   @RequestParam(value = "perpage", required = false) Integer perpage,
                                                                   @Parameter(
                                                                           description = "Facets parameters should be provided with putting multiple f.{filter-name}={value} as request parameters. Allowed filter names: "
@@ -94,7 +94,7 @@ class SearchController {
     @GetMapping(path = "/actor-search", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Search among actors.")
     public ResponseEntity<PaginatedSearchActor> searchActors(@RequestParam(value = "q", required = false) String q,
-                                                             @RequestParam(value = "page", required = false) Integer page,
+                                                             @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                              @RequestParam(value = "perpage", required = false) Integer perpage,
                                                              @Parameter(
                                                                      description = "Dynamic property filter parameters should be provided with putting multiple d.{property}={expression} as request parameters. Allowed property codes: "
@@ -113,7 +113,7 @@ class SearchController {
     @Operation(description = "Search among actors.")
     public ResponseEntity<PaginatedSearchCollection> searchCollections(
             @RequestParam(value = "q", required = false) String q,
-            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
             @RequestParam(value = "advanced", defaultValue = "false") boolean advanced,
             @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/sources/SourceController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/sources/SourceController.java
@@ -33,7 +33,7 @@ public class SourceController {
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedSources> getSources(@RequestParam(value = "order", required = false) SourceOrder order,
                                                        @RequestParam(value = "q", required = false) String q,
-                                                       @RequestParam(value = "page", required = false) Integer page,
+                                                       @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                        @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(sourceService.getSources(order, q, pageCoordsValidator.validate(page, perpage)));
@@ -70,7 +70,7 @@ public class SourceController {
     @Operation(summary = "Get list of items for given source")
     @GetMapping(path = "/{sourceId}/items", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemsBasic<ItemBasicDto>> getItemsForSource(@PathVariable("sourceId") Long sourceId,
-                                                                       @RequestParam(value = "page", required = false) Integer page,
+                                                                       @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                        @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getItemsBySource(sourceId, null, pageCoordsValidator.validate(page, perpage)));
@@ -80,7 +80,7 @@ public class SourceController {
     @GetMapping(path = "/{sourceId}/items/{sourceItemId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemsBasic<ItemBasicDto>> getItemsForSourceAndSourceItemId(@PathVariable("sourceId") Long sourceId,
                                                                                               @PathVariable("sourceItemId") String sourceItemId,
-                                                                                              @RequestParam(value = "page", required = false) Integer page,
+                                                                                              @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                                               @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getItemsBySource(sourceId, sourceItemId, pageCoordsValidator.validate(page, perpage)));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/sources/SourceController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/sources/SourceController.java
@@ -34,7 +34,7 @@ public class SourceController {
     public ResponseEntity<PaginatedSources> getSources(@RequestParam(value = "order", required = false) SourceOrder order,
                                                        @RequestParam(value = "q", required = false) String q,
                                                        @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                       @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                       @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(sourceService.getSources(order, q, pageCoordsValidator.validate(page, perpage)));
     }
@@ -71,7 +71,7 @@ public class SourceController {
     @GetMapping(path = "/{sourceId}/items", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedItemsBasic<ItemBasicDto>> getItemsForSource(@PathVariable("sourceId") Long sourceId,
                                                                        @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                                       @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                                       @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getItemsBySource(sourceId, null, pageCoordsValidator.validate(page, perpage)));
     }
@@ -81,7 +81,7 @@ public class SourceController {
     public ResponseEntity<PaginatedItemsBasic<ItemBasicDto>> getItemsForSourceAndSourceItemId(@PathVariable("sourceId") Long sourceId,
                                                                                               @PathVariable("sourceItemId") String sourceItemId,
                                                                                               @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                                                              @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                                                              @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(itemService.getItemsBySource(sourceId, sourceItemId, pageCoordsValidator.validate(page, perpage)));
     }

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/tools/ToolController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/tools/ToolController.java
@@ -15,6 +15,7 @@ import eu.sshopencloud.marketplace.validators.PageCoordsValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -34,8 +35,8 @@ public class ToolController {
 
     @Operation(summary = "Retrieve all tools services in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PaginatedTools> getTools(@RequestParam(value = "page", required = false) Integer page,
-                                                   @RequestParam(value = "perpage", required = false) Integer perpage,
+    public ResponseEntity<PaginatedTools> getTools(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
+                                                   @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage,
                                                    @RequestParam(value = "approved", defaultValue = "true") boolean approved)
             throws PageTooLargeException {
         return ResponseEntity.ok(toolService.getTools(pageCoordsValidator.validate(page, perpage), approved));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/trainings/TrainingMaterialController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/trainings/TrainingMaterialController.java
@@ -34,7 +34,7 @@ public class TrainingMaterialController {
 
     @Operation(summary = "Retrieve all training materials in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PaginatedTrainingMaterials> getTrainingMaterials(@RequestParam(value = "page", required = false) Integer page,
+    public ResponseEntity<PaginatedTrainingMaterials> getTrainingMaterials(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                            @RequestParam(value = "perpage", required = false) Integer perpage,
                                                                            @RequestParam(value = "approved", defaultValue = "true") boolean approved)
             throws PageTooLargeException {

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/trainings/TrainingMaterialController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/trainings/TrainingMaterialController.java
@@ -35,7 +35,7 @@ public class TrainingMaterialController {
     @Operation(summary = "Retrieve all training materials in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedTrainingMaterials> getTrainingMaterials(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                                           @RequestParam(value = "perpage", required = false) Integer perpage,
+                                                                           @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage,
                                                                            @RequestParam(value = "approved", defaultValue = "true") boolean approved)
             throws PageTooLargeException {
         return ResponseEntity.ok(trainingMaterialService.getTrainingMaterials(pageCoordsValidator.validate(page, perpage), approved));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/vocabularies/PropertyTypeController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/vocabularies/PropertyTypeController.java
@@ -30,7 +30,7 @@ public class PropertyTypeController {
     @Operation(summary = "Get all property types in pages")
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedPropertyTypes> getPropertyTypes(@RequestParam(value = "q", required = false) String q,
-                                                                   @RequestParam(value = "page", required = false) Integer page,
+                                                                   @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                    @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
 

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/vocabularies/PropertyTypeController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/vocabularies/PropertyTypeController.java
@@ -31,7 +31,7 @@ public class PropertyTypeController {
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedPropertyTypes> getPropertyTypes(@RequestParam(value = "q", required = false) String q,
                                                                    @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                                   @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                                   @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
 
         return ResponseEntity.ok(propertyTypeService.getPropertyTypes(q, pageCoordsValidator.validate(page, perpage)));

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/vocabularies/VocabularyController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/vocabularies/VocabularyController.java
@@ -9,6 +9,7 @@ import eu.sshopencloud.marketplace.services.vocabularies.exception.VocabularyAlr
 import eu.sshopencloud.marketplace.services.vocabularies.VocabularyService;
 import eu.sshopencloud.marketplace.validators.PageCoordsValidator;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -31,7 +32,7 @@ public class VocabularyController {
 
     @Operation(summary = "Get all vocabularies in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PaginatedVocabularies> getVocabularies(@RequestParam(value = "page", required = false) Integer page,
+    public ResponseEntity<PaginatedVocabularies> getVocabularies(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                                  @RequestParam(value = "perpage", required = false) Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(vocabularyService.getVocabularies(pageCoordsValidator.validate(page, perpage)));
@@ -40,7 +41,7 @@ public class VocabularyController {
     @Operation(summary = "Get vocabulary for given code")
     @GetMapping(path = "/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<VocabularyDto> getVocabulary(@PathVariable("code") String code,
-                                                       @RequestParam(value = "page", required = false) Integer page,
+                                                       @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                        @RequestParam(value = "perpage", required = false) Integer perPage)
             throws PageTooLargeException {
 

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/vocabularies/VocabularyController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/vocabularies/VocabularyController.java
@@ -33,7 +33,7 @@ public class VocabularyController {
     @Operation(summary = "Get all vocabularies in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedVocabularies> getVocabularies(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                                 @RequestParam(value = "perpage", required = false) Integer perpage)
+                                                                 @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage)
             throws PageTooLargeException {
         return ResponseEntity.ok(vocabularyService.getVocabularies(pageCoordsValidator.validate(page, perpage)));
     }
@@ -42,7 +42,7 @@ public class VocabularyController {
     @GetMapping(path = "/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<VocabularyDto> getVocabulary(@PathVariable("code") String code,
                                                        @RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                       @RequestParam(value = "perpage", required = false) Integer perPage)
+                                                       @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perPage)
             throws PageTooLargeException {
 
         PageCoords pageCoords = pageCoordsValidator.validate(page, perPage);

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/workflows/WorkflowController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/workflows/WorkflowController.java
@@ -34,7 +34,7 @@ public class WorkflowController {
 
     @Operation(summary = "Retrieve all workflows in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PaginatedWorkflows> getWorkflows(@RequestParam(value = "page", required = false) Integer page,
+    public ResponseEntity<PaginatedWorkflows> getWorkflows(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
                                                            @RequestParam(value = "perpage", required = false) Integer perpage,
                                                            @RequestParam(value = "approved", defaultValue = "true") boolean approved)
             throws PageTooLargeException {

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/workflows/WorkflowController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/workflows/WorkflowController.java
@@ -35,7 +35,7 @@ public class WorkflowController {
     @Operation(summary = "Retrieve all workflows in pages")
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PaginatedWorkflows> getWorkflows(@RequestParam(value = "page", required = false) @Schema(description = "Page numbers start at 1", minimum = "1") Integer page,
-                                                           @RequestParam(value = "perpage", required = false) Integer perpage,
+                                                           @RequestParam(value = "perpage", required = false) @Schema(minimum = "1") Integer perpage,
                                                            @RequestParam(value = "approved", defaultValue = "true") boolean approved)
             throws PageTooLargeException {
         return ResponseEntity.ok(workflowService.getWorkflows(pageCoordsValidator.validate(page, perpage), approved));

--- a/src/main/java/eu/sshopencloud/marketplace/dto/auth/UserDto.java
+++ b/src/main/java/eu/sshopencloud/marketplace/dto/auth/UserDto.java
@@ -22,7 +22,7 @@ public class UserDto {
 
     private UserStatus status;
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.outputDateTimePattern, example = ApiDateTimeFormatter.outputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.outputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.outputDateTimePattern)
     private ZonedDateTime registrationDate;
 

--- a/src/main/java/eu/sshopencloud/marketplace/dto/collections/CollectionDto.java
+++ b/src/main/java/eu/sshopencloud/marketplace/dto/collections/CollectionDto.java
@@ -26,11 +26,11 @@ public class CollectionDto {
 
     private List<CollectionItemDto> collectionItems;
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.outputDateTimePattern, example = ApiDateTimeFormatter.outputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.outputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.outputDateTimePattern)
     private ZonedDateTime createdAt;
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.outputDateTimePattern, example = ApiDateTimeFormatter.outputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.outputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.outputDateTimePattern)
     private ZonedDateTime updatedAt;
 

--- a/src/main/java/eu/sshopencloud/marketplace/dto/items/DigitalObjectCore.java
+++ b/src/main/java/eu/sshopencloud/marketplace/dto/items/DigitalObjectCore.java
@@ -15,12 +15,12 @@ import java.time.ZonedDateTime;
 @NoArgsConstructor
 public class DigitalObjectCore extends ItemCore {
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.inputDateTimePattern, example = ApiDateTimeFormatter.inputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.inputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.inputDateTimePattern)
     @Nullable
     private ZonedDateTime dateCreated;
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.inputDateTimePattern, example = ApiDateTimeFormatter.inputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.inputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.inputDateTimePattern)
     @Nullable
     private ZonedDateTime dateLastUpdated;

--- a/src/main/java/eu/sshopencloud/marketplace/dto/items/DigitalObjectDto.java
+++ b/src/main/java/eu/sshopencloud/marketplace/dto/items/DigitalObjectDto.java
@@ -15,12 +15,12 @@ import java.time.ZonedDateTime;
 @NoArgsConstructor
 public class DigitalObjectDto extends ItemDto {
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.outputDateTimePattern, example = ApiDateTimeFormatter.outputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.outputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.outputDateTimePattern)
     @Nullable
     private ZonedDateTime dateCreated;
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.outputDateTimePattern, example = ApiDateTimeFormatter.outputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.outputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.outputDateTimePattern)
     @Nullable
     private ZonedDateTime dateLastUpdated;

--- a/src/main/java/eu/sshopencloud/marketplace/dto/items/ItemBasicDto.java
+++ b/src/main/java/eu/sshopencloud/marketplace/dto/items/ItemBasicDto.java
@@ -25,7 +25,7 @@ public class ItemBasicDto {
 
     private String persistentId;
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.outputDateTimePattern, example = ApiDateTimeFormatter.outputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.outputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.outputDateTimePattern)
     private ZonedDateTime lastInfoUpdate;
 

--- a/src/main/java/eu/sshopencloud/marketplace/dto/items/ItemCommentDto.java
+++ b/src/main/java/eu/sshopencloud/marketplace/dto/items/ItemCommentDto.java
@@ -20,11 +20,11 @@ public class ItemCommentDto {
 
     private UserDto creator;
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.outputDateTimePattern, example = ApiDateTimeFormatter.outputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.outputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.outputDateTimePattern)
     private ZonedDateTime dateCreated;
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.outputDateTimePattern, example = ApiDateTimeFormatter.outputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.outputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.outputDateTimePattern)
     @Nullable
     private ZonedDateTime dateLastUpdated;

--- a/src/main/java/eu/sshopencloud/marketplace/dto/sources/SourceDto.java
+++ b/src/main/java/eu/sshopencloud/marketplace/dto/sources/SourceDto.java
@@ -15,7 +15,7 @@ import java.time.ZonedDateTime;
 @NoArgsConstructor
 public class SourceDto extends SourceBasicDto {
 
-    @Schema(type="string", pattern = ApiDateTimeFormatter.outputDateTimePattern, example = ApiDateTimeFormatter.outputDateTimeExample)
+    @Schema(format = "date-time", example = ApiDateTimeFormatter.outputDateTimeExample)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ApiDateTimeFormatter.outputDateTimePattern)
     @Nullable
     private ZonedDateTime lastHarvestedDate;

--- a/src/main/java/eu/sshopencloud/marketplace/validators/PageCoordsValidator.java
+++ b/src/main/java/eu/sshopencloud/marketplace/validators/PageCoordsValidator.java
@@ -18,6 +18,20 @@ public class PageCoordsValidator {
         if (perpage != null && perpage > maximalPerpage) {
             throw new PageTooLargeException(maximalPerpage);
         }
+
+        if (page != null && page <= 0) {
+            // this is probably overkill given the use of @Schema on the controllers
+            // but if something does sneak past that then this catches the out of bounds
+            // error which would otherwise be caught when calling PageRequest.of()
+            // and this ensures that the resulting error message is now correct, rather
+            // than it stating it "must not be less than zero" when the caller provided
+            // a zero value. In an ideal world the API would use zero based indexes for
+            // the page ranges and the UI would add one, rather than us having to take
+            // one away every time. Note that we throw an IllegalArgumentException so
+            // as not to change the signature of the method and maintain previous behaviour
+            throw new IllegalArgumentException("Page index must be 1 or more");
+        }
+
         return PageCoords.builder()
                 .perpage(perpage == null ? defualtPerpage : perpage)
                 .page(page == null ? 1 : page)


### PR DESCRIPTION
When completing the [programming assignment for the ATRIUM RSE job](https://github.com/greenwoodma/atrium-rse-assessment/), I discovered a couple of small issues with the OpenAPI specification published at https://marketplace-api.sshopencloud.eu/v3/api-docs

Specifically there were two issues both of which are addressed by this PR:

1. Dates were incorrectly defined as type `string` with a standard RFC3339 pattern used in the `pattern` attribute. Unfortunately the `pattern` attribute is treated as a regex which meant no date would ever be valid, which in turn made it impossible to auto-generate a client library from the published specification. The fix is easy as we just use `format="date-time"` instead which then matches any valid RFC3339 date time.
2. Pagination in the API assumes that the first page is 1 not 0 as most consumers of the API would likely assume. Unfortunately not only is this not documented, but if you provide 0 as the page number you get the odd message that _"Page index must not be less than zero"_. The fix for this is in two parts. Firstly setting a minimum value and a description on the controller endpoints so that 0 is never a valid value. Secondly (in case a new endpoint is added without the correct annotations) a check is also performed in `PageCoordsValidator` so that a more correct error message can be returned.

While not strictly related the PR also adds a minimum value of 1 to the `perpage` parameters of the same endpoints. Annoyingly I've not _yet_ figured out a way to set the maximum value given it is configurable in `application.yml`.

With these fixes in place the code I used for the programming assignment will now run correctly.