### PR TITLE
Improve documentation for PATCH endpoints

### DIFF
--- a/src/main/java/eu/sshopencloud/marketplace/controllers/datasets/DatasetController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/datasets/DatasetController.java
@@ -81,7 +81,16 @@ public class DatasetController {
         return ResponseEntity.ok(datasetService.updateDataset(persistentId, updatedDataset, draft, approved, false));
     }
 
-    @Operation(summary = "Patch dataset for given persistentId")
+    @Operation(
+        summary = "Patch dataset for given persistentId",
+        description = """
+            Updates a dataset record by replacing field values with those supplied in the patch body.
+            Note that providing a value for any field completely replaces the previous value. This is
+            especially important to remember when updating any of the array value fields, as all
+            existing entires will be removed and replaced with the values provided in the patch. If
+            you wish to add to an existing array then you **must** provide the existing values as well
+            as the new value in the patch body otherwise data loss will occur."""
+    )
     @PatchMapping(path = "/{persistentId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<DatasetDto> patchDataset(@PathVariable("persistentId") String persistentId,
                                                     @Parameter(

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/publications/PublicationController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/publications/PublicationController.java
@@ -82,7 +82,16 @@ public class PublicationController {
         return ResponseEntity.ok(publicationService.updatePublication(persistentId, updatedPublication, draft, approved, false));
     }
 
-    @Operation(summary = "Patch publication for given persistentId")
+    @Operation(
+        summary = "Patch publication for given persistentId",
+        description = """
+            Updates a publication record by replacing field values with those supplied in the patch body.
+            Note that providing a value for any field completely replaces the previous value. This is
+            especially important to remember when updating any of the array value fields, as all
+            existing entires will be removed and replaced with the values provided in the patch. If
+            you wish to add to an existing array then you **must** provide the existing values as well
+            as the new value in the patch body otherwise data loss will occur."""
+    )
     @PatchMapping(path = "/{persistentId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PublicationDto> patchPublication(@PathVariable("persistentId") String persistentId,
                                                             @Parameter(

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/tools/ToolController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/tools/ToolController.java
@@ -69,7 +69,16 @@ public class ToolController {
     }
 
 
-    @Operation(summary = "Updating tool for given persistentId")
+    @Operation(
+        summary = "Updating tool for given persistentId",
+        description = """
+            Updates a tool record by replacing field values with those supplied in the patch body.
+            Note that providing a value for any field completely replaces the previous value. This is
+            especially important to remember when updating any of the array value fields, as all
+            existing entires will be removed and replaced with the values provided in the patch. If
+            you wish to add to an existing array then you **must** provide the existing values as well
+            as the new value in the patch body otherwise data loss will occur."""
+    )
     @PutMapping(path = "/{persistentId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ToolDto> updateTool(@PathVariable("persistentId") String persistentId,
                                               @Parameter(

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/trainings/TrainingMaterialController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/trainings/TrainingMaterialController.java
@@ -83,7 +83,16 @@ public class TrainingMaterialController {
         return ResponseEntity.ok(trainingMaterialService.updateTrainingMaterial(persistentId, updatedTrainingMaterial, draft, approved, false));
     }
 
-    @Operation(summary = "Patch training material for given persistentId")
+    @Operation(
+        summary = "Patch training material for given persistentId",
+        description = """
+            Updates a trainging material record by replacing field values with those supplied in
+            the patch body. Note that providing a value for any field completely replaces the
+            previous value. This is especially important to remember when updating any of the array
+            value fields, as all existing entires will be removed and replaced with the values
+            provided in the patch. If you wish to add to an existing array then you **must** provide
+            the existing values as well as the new value in the patch body otherwise data loss will occur."""
+    )
     @PatchMapping(path = "/{persistentId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<TrainingMaterialDto> patchTrainingMaterial(@PathVariable("persistentId") String persistentId,
                                                                       @Parameter(

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/trainings/TrainingMaterialController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/trainings/TrainingMaterialController.java
@@ -86,7 +86,7 @@ public class TrainingMaterialController {
     @Operation(
         summary = "Patch training material for given persistentId",
         description = """
-            Updates a trainging material record by replacing field values with those supplied in
+            Updates a training material record by replacing field values with those supplied in
             the patch body. Note that providing a value for any field completely replaces the
             previous value. This is especially important to remember when updating any of the array
             value fields, as all existing entires will be removed and replaced with the values

--- a/src/main/java/eu/sshopencloud/marketplace/controllers/workflows/WorkflowController.java
+++ b/src/main/java/eu/sshopencloud/marketplace/controllers/workflows/WorkflowController.java
@@ -82,7 +82,16 @@ public class WorkflowController {
         return ResponseEntity.ok(workflowService.updateWorkflow(workflowPersistentId, updatedWorkflow, draft, approved, false));
     }
 
-    @Operation(summary = "Patch  workflow for given persistentId")
+    @Operation(
+        summary = "Patch workflow for given persistentId",
+        description = """
+            Updates a workflow record by replacing field values with those supplied in the patch body.
+            Note that providing a value for any field completely replaces the previous value. This is
+            especially important to remember when updating any of the array value fields, as all
+            existing entires will be removed and replaced with the values provided in the patch. If
+            you wish to add to an existing array then you **must** provide the existing values as well
+            as the new value in the patch body otherwise data loss will occur."""
+    )
     @PatchMapping(path = "/{persistentId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<WorkflowDto> patchWorkflow(@PathVariable("persistentId") String workflowPersistentId,
                                                       @Parameter(
@@ -183,7 +192,16 @@ public class WorkflowController {
         return ResponseEntity.ok(stepService.updateStep(workflowPersistentId, stepPersistentId, updatedStep, draft, approved, false));
     }
 
-    @Operation(summary = "Patch step for given persistentId and workflow persistentId")
+    @Operation(
+        summary = "Patch step for given persistentId and workflow persistentId",
+        description = """
+            Updates a workflow step record by replacing field values with those supplied in the patch body.
+            Note that providing a value for any field completely replaces the previous value. This is
+            especially important to remember when updating any of the array value fields, as all
+            existing entires will be removed and replaced with the values provided in the patch. If
+            you wish to add to an existing array then you **must** provide the existing values as well
+            as the new value in the patch body otherwise data loss will occur."""
+    )
     @PatchMapping(path = "/{persistentId}/steps/{stepPersistentId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<StepDto> patchStep(@PathVariable("persistentId") String workflowPersistentId,
                                               @PathVariable("stepPersistentId") String stepPersistentId,


### PR DESCRIPTION
As discussed in #562 the current documentation of the PATCH endpoints does not make clear the exact semantics of the operation, especially concerning the array valued fields. This PR adds a description field to the OpenAPI documentation for each of the PATCH endpoints which makes the semantics explicit and provides details of how to avoid the accidental data loss described in #562.